### PR TITLE
Change order of demo sample snippets

### DIFF
--- a/src/components/UsfmEditor.md
+++ b/src/components/UsfmEditor.md
@@ -9,56 +9,6 @@ const usfmStrings = new Map([
 \\s section
 `],
 
-["usfmString0", `
-\\id GEN
-\\c 1
-\\p
-Before a verse
-\\v 1 the first verse.
-\\v 2 the second verse. 
-\\p
-\\v 3 hello.
-\\v 4 hello again
-\\s section
-\\p another p
-\\v 5 A very very long verse indeed in fact it is so long that I am worried that my stream of consciousness will run out of things to say very soon but so far it hasn't happened 
-\\p
-\\v 6 \\nd God\\nd* Another verse
-\\p Here we go again \\nd Lord \\nd*
-\\p
-\\v 7
-\\s sectiona
-\\p
-A seventh verse
-\\v 8 An eighth verse
-\\p \\nd Lord \\nd*only knows
-\\p
-\\v 9 A ninth verse
-\\p paraghraph \\nd Lord \\nd*only knows \\nd God \\nd*
-`],
-
-["usfmString1", `
-\\id GEN
-\\c 1
-\\p Front stuffs
-\\v 1 the first verse
-\\v 2 the second verse
-\\v 15 Tell the Israelites that I, 
-the \\nd Lord\\nd*, the God of their 
-ancestors, the God of Abraham, Isaac, 
-and Jacob,
-`],
-
-["usfmString2", `
-\\id GEN
-\\c 1
-\\v 1 the first verse
-\\v 2 the second verse
-\\c 2
-\\v 1 the first verse
-\\v 2 the second verse
-`],
-
 ["Mark 1 paragraphs", `
 \\id MRK Unlocked Literal Bible
 \\ide UTF-8
@@ -306,13 +256,64 @@ the area of Suphah
 \\v 55 and the clans of the scribes who lived at Jabez: the Tirathites, Shimeathites, and Sucathites. These were the Kenites who came from Hammath, father of the house of Rekab.
 
 \\s5
-`]
+`],
+
+["usfmTestString0", `
+\\id GEN
+\\c 1
+\\p
+Before a verse
+\\v 1 the first verse.
+\\v 2 the second verse. 
+\\p
+\\v 3 hello.
+\\v 4 hello again
+\\s section
+\\p another p
+\\v 5 A very very long verse indeed in fact it is so long that I am worried that my stream of consciousness will run out of things to say very soon but so far it hasn't happened 
+\\p
+\\v 6 \\nd God\\nd* Another verse
+\\p Here we go again \\nd Lord \\nd*
+\\p
+\\v 7
+\\s sectiona
+\\p
+A seventh verse
+\\v 8 An eighth verse
+\\p \\nd Lord \\nd*only knows
+\\p
+\\v 9 A ninth verse
+\\p paraghraph \\nd Lord \\nd*only knows \\nd God \\nd*
+`],
+
+["usfmTestString1", `
+\\id GEN
+\\c 1
+\\p Front stuffs
+\\v 1 the first verse
+\\v 2 the second verse
+\\v 15 Tell the Israelites that I, 
+the \\nd Lord\\nd*, the God of their 
+ancestors, the God of Abraham, Isaac, 
+and Jacob,
+`],
+
+["usfmTestString2", `
+\\id GEN
+\\c 1
+\\v 1 the first verse
+\\v 2 the second verse
+\\c 2
+\\v 1 the first verse
+\\v 2 the second verse
+`],
+
 ]);
 
 class DemoEditor extends React.Component {
     constructor(props) {
         super(props);
-        this.state = {usfmInput: usfmStrings.get("usfmString0")};
+        this.state = {usfmInput: usfmStrings.get("small")};
         this.handleCannedDemoSelectionChange = event => this.setState({ usfmInput: event.target.value });
         this.handleEditorChange = (usfm) => this.setState({ usfmOutput: usfm });
     }


### PR DESCRIPTION
Change order of demo sample snippets so the page isn't so cluttered upon first load, and make the first item in the selection list the one that is initialized.