### PR TITLE
Only add sourceTextField to tag data if applicable

### DIFF
--- a/src/components/jsonTransforms/usfmjsToSlateRules.js
+++ b/src/components/jsonTransforms/usfmjsToSlateRules.js
@@ -116,7 +116,7 @@ export const slateRules = [
             return ({
                 "object": "block",
                 "type": d.match,
-                "data": {"source": d.context, "sourceTextField": getSourceTextField(d.context)},
+                "data": buildTagData(d.context),
                 "nodes": [
                     d.context.text ? bareTextNode(d.context.text) : null,
                     d.context.content ? bareTextNode(d.context.content) : null,
@@ -141,11 +141,12 @@ function shouldAddEmptyTextFieldToParagraph(match, context) {
         !context.hasOwnProperty("text")
 }
 
-function getSourceTextField(context) {
-    if (context.hasOwnProperty("text"))
-        return "text"
-    else if (context.hasOwnProperty("content"))
-        return "content"
-    else 
-        throw new Error("Match context has no \"text\" or \"content\" field")
+function buildTagData(context) {
+    const data = {"source": context}
+    if (context.hasOwnProperty("text")) {
+        data["sourceTextField"] = "text"
+    } else if (context.hasOwnProperty("content")) {
+        data["sourceTextField"] = "content"
+    }
+    return data
 }


### PR DESCRIPTION
Not every tag will have source text (an example is the horizontal line, s5.) This PR fixes a bug where tags that are found without source text would throw an error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aunger/slate-usfm/11)
<!-- Reviewable:end -->
